### PR TITLE
Add endpoint_called_at field

### DIFF
--- a/src/spaceone/plugin/error/supervisor.py
+++ b/src/spaceone/plugin/error/supervisor.py
@@ -31,5 +31,6 @@ class ERROR_NOT_SUPPORT_LIST_PLUGINS(ERROR_BASE):
     _message = 'This supervisor does not support list plugins: {supervisor_id}'
 
 
-class ERROR_INSTALLED_PLUGIN_EXIST(ERROR_BASE): 
+class ERROR_INSTALLED_PLUGIN_EXIST(ERROR_BASE):
     _message = 'Installed plugins exist, {supervisor_id}'
+

--- a/src/spaceone/plugin/model/installed_plugin_model.py
+++ b/src/spaceone/plugin/model/installed_plugin_model.py
@@ -27,6 +27,7 @@ class InstalledPlugin(MongoModel):
     endpoints = ListField(StringField(max_length=255))
     created_at = DateTimeField(auto_now_add=True)
     updated_at = DateTimeField(auto_now_add=True)
+    endpoint_called_at = DateTimeField(default=None, null=True)
 
     meta = {
         'db_alias': 'default',
@@ -35,7 +36,8 @@ class InstalledPlugin(MongoModel):
             'updated_at',
             'state',
             'endpoint',
-            'endpoints'
+            'endpoints',
+            'endpoint_called_at'
         ],
         'exact_fields': [
             'plugin_id',
@@ -66,10 +68,15 @@ class InstalledPlugin(MongoModel):
             'name',
             'image',
             'version',
-            'state'
+            'state',
+            'endpoint_called_at'
         ]
     }
 
     def update(self, data):
         data['updated_at'] = datetime.datetime.now()
+        return super().update(data)
+
+    def update_endpoint_called_at(self):
+        data = {'endpoint_called_at': datetime.datetime.now()}
         return super().update(data)

--- a/src/spaceone/plugin/service/plugin_service.py
+++ b/src/spaceone/plugin/service/plugin_service.py
@@ -120,6 +120,10 @@ class PluginService(BaseService):
         """ Select one of plugins, then return endpoint
         """
         installed_plugin = plugin_ref.plugin_owner
+
+        # Update endpoint_called_at
+        installed_plugin.update_endpoint_called_at()
+
         # plugin state = ACTIVE | PROVISIONING
         state = installed_plugin.state
         if state == 'ACTIVE':


### PR DESCRIPTION
When get_plugin_endpoint is called, the called date is updated.
This is for un-used plugin garbage collection.

Signed-off-by: “Choonho <choonhoson@megazone.com>